### PR TITLE
Overhaul

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,17 @@
+{
+  "rules": {
+    "indent": [2, 2],
+    "quotes": [2, "single"],
+    "no-console": [0],
+    "semi": [2, "always"]
+  },
+  "env": {
+      "node": true
+  },
+  "globals": {
+      "process": true,
+      "module": true,
+      "require": true
+  },
+  "extends": "eslint:recommended"
+}

--- a/index.js
+++ b/index.js
@@ -1,138 +1,165 @@
-var AWS = require('aws-sdk');
 var stream = require('stream');
-var util = require('util');
 
-// required config:
-// - name
-// - region
-//
-// optional config:
-// - endpoint
-// - accessKeyId
-// - secretAccesKey
-// - sessionToken
+module.exports = KinesisReadable;
 
-module.exports = function(config) {
-  var kinesis = new AWS.Kinesis({
-    endpoint: config.endpoint,
-    accessKeyId: config.accessKeyId,
-    secretAccessKey: config.secretAccessKey,
-    sessionToken: config.sessionToken,
-    region: config.region
-  });
-
-  util.inherits(KinesisReadable, stream.Readable);
-
-  // Optional:
-  // - shardId: to read from
-  // - latest: to only read records written after you start listening
-  // - lastCheckpoint: start reading the record after the given sequence number
-  // - limit: max number of records that will be passed to `data` event
-  function KinesisReadable(options) {
-    options = options || {};
-
-    this.name = config.name;
-    this.shardId = options.shardId;
-    this.kinesis = kinesis;
-    this.iterator = null;
-    this.pending = 0;
-    this.latest = !!options.latest;
-    this.lastCheckpoint = options.lastCheckpoint;
-    this.limit = Math.min(10000, options.limit) || 1;
-
-    stream.Readable.call(this, { objectMode: true });
+/**
+ * A factory to generate a {@link KinesisClient} that pulls records from a Kinesis stream
+ *
+ * @param {object} client - an AWS.Kinesis client capable of reading the desired stream
+ * @param {string} [name] - the name of the shard to read. Not required if already
+ * set by the provided AWS.Kinesis client.
+ * @param {object} [options] - configuration details
+ * @param {string} [options.shardId] - the shard id to read from. Each KinesisReadable
+ * instance is only capable of reading a single shard. If unspecified, the instance
+ * will read from the first shard returned by a DescribeStream request.
+ * @param {string} [options.iterator] - the iterator type. One of `LATEST` or `TRIM_HORIZON`.
+ * If unspecified, defaults to `TRIM_HORIZON`
+ * @param {string} [options.startAt] - a sequence number to start reading from.
+ * @param {string} [options.startAfter] - a sequence number to start reading after.
+ * @param {number} [options.limit] - the maximum number of records that will
+ * be passed to any single `data` event.
+ * @returns {KinesisClient} a readable stream of kinesis records
+ */
+function KinesisReadable(client, name, options) {
+  if (typeof name === 'object') {
+    options = name;
+    name = undefined;
   }
 
-  KinesisReadable.prototype.close = function(callback) {
-    callback = callback || function() {};
-    var _this = this;
+  if (!options) options = {};
 
-    _this.drain = true;
-    if (_this.pending) return setImmediate(_this.close.bind(_this), callback);
+  if (options.iterator && options.iterator !== 'LATEST' && options.iterator !== 'TRIM_HORIZON')
+    throw new Error('options.iterator must be one of LATEST or TRIM_HORIZON');
 
-    _this.once('end', callback);
+  var readable = new stream.Readable({
+    objectMode: true,
+    highWaterMark: 100
+  });
 
-    _this.push(null);
-    _this.resume();
-  };
+  var checkpoint = new stream.Transform({
+    objectMode: true,
+    highWaterMark: 100
+  });
 
-  KinesisReadable.prototype._read = function read() {
-    var _this = this;
-    if (_this.drain) return;
-    if (!_this.iterator) return _this._describe(haveIterator);
-    haveIterator();
+  var iterator, drain, ended, pending = 0;
 
-    function haveIterator(err) {
-      if (_this.drain) return;
-      if (err) return _this.emit('error', err);
+  function describeStream(callback) {
+    pending++;
+    client.describeStream({ StreamName: name }, function(err, data) {
+      pending--;
+      if (err) return callback(err);
 
-      _this.pending++;
-      kinesis.getRecords({
-        ShardIterator: _this.iterator,
-        Limit: _this.limit
-      }, function(err, data) {
-        _this.pending--;
-        if (err) return _this.emit('error', err);
+      var shardId = options.shardId ?
+        data.StreamDescription.Shards.filter(function(shard) {
+          return shard.ShardId === options.shardId;
+        }).map(function(shard) {
+          return shard.ShardId;
+        })[0] : data.StreamDescription.Shards[0].ShardId;
 
-        _this.iterator = data.NextShardIterator;
+      if (!shardId) return callback(new Error('Shard ' + options.shardId + ' does not exist'));
+      getShardIterator(shardId, callback);
+    });
+  }
 
-        if (!data.Records.length) return setImmediate(function() {
-          _this._read();
-        });
+  function getShardIterator(shardId, callback) {
+    var params = {
+      ShardId: shardId,
+      StreamName: name
+    };
 
-        _this.push(data.Records);
-        _this.emit('checkpoint', data.Records.slice(-1)[0].SequenceNumber);
-      });
+    if (options.iterator) {
+      params.ShardIteratorType = options.iterator;
+    } else if (options.startAt) {
+      params.ShardIteratorType = 'AT_SEQUENCE_NUMBER';
+      params.StartingSequenceNumber = options.startAt;
+    } else if (options.startAfter) {
+      params.ShardIteratorType = 'AFTER_SEQUENCE_NUMBER';
+      params.StartingSequenceNumber = options.startAfter;
+    } else {
+      params.ShardIteratorType = 'TRIM_HORIZON';
+    }
+
+    pending++;
+    client.getShardIterator(params, function(err, data) {
+      pending--;
+      if (err) return callback(err);
+      iterator = data.ShardIterator;
+      callback();
+    });
+  }
+
+  function read(callback) {
+    if (drain && !pending) return callback(null, { Records: null });
+    if (drain && pending) return setImmediate(read, callback);
+
+    pending++;
+    client.getRecords({
+      ShardIterator: iterator,
+      Limit: options.limit
+    }, function(err, data) {
+      pending--;
+      if (err) return callback(err);
+
+      iterator = data.NextShardIterator;
+
+      if (!data.Records.length) {
+        if (!drain) return setTimeout(read, 200, callback);
+        data.Records = null;
+      }
+
+      callback(null, data);
+    });
+  }
+
+  readable._read = function() {
+    if (iterator) return read(gotRecords);
+
+    describeStream(function(err) {
+      if (err) return checkpoint.emit('error', err);
+      read(gotRecords);
+    });
+
+    function gotRecords(err, data) {
+      if (err) return checkpoint.emit('error', err);
+      setTimeout(readable.push.bind(readable), 200, data.Records);
     }
   };
 
-  KinesisReadable.prototype._describe = function describe(callback) {
-    var _this = this;
-    if (_this.drain) return callback();
-
-    _this.kinesis.describeStream({
-      StreamName: _this.name
-    }, function(err, data) {
-      if (err) return callback(err);
-      if (_this.drain) return callback();
-
-      if (typeof _this.shardId === 'string') {
-        var match = data.StreamDescription.Shards.filter(function(shard) {
-          return shard.ShardId === _this.shardId;
-        });
-        if (match.length === 0)
-          return callback(new Error('Shard ' + _this.shardId + ' does not exist'));
-      } else {
-        _this.shardId = data.StreamDescription.Shards[0].ShardId;
-      }
-
-      var params = {
-        StreamName: _this.name,
-        ShardId: _this.shardId,
-        ShardIteratorType: 'AT_SEQUENCE_NUMBER',
-        StartingSequenceNumber: data.StreamDescription.Shards[0].SequenceNumberRange.StartingSequenceNumber
-      };
-
-      if (_this.latest) {
-        params.ShardIteratorType = 'LATEST';
-        delete params.StartingSequenceNumber;
-        _this.latest = false;
-      }
-
-      if (_this.lastCheckpoint) {
-        params.ShardIteratorType = 'AFTER_SEQUENCE_NUMBER';
-        params.StartingSequenceNumber = _this.lastCheckpoint;
-        _this.lastCheckpoint = false;
-      }
-
-      kinesis.getShardIterator(params, function(err, data) {
-        if (err) return callback(err);
-        if (_this.drain) return callback();
-        _this.iterator = data.ShardIterator;
-        callback();
-      });
-    });
+  checkpoint._transform = function(data, enc, callback) {
+    checkpoint.emit('checkpoint', data.slice(-1)[0].SequenceNumber);
+    callback(null, data);
   };
 
-  return KinesisReadable;
-};
+  checkpoint._flush = function(callback) {
+    ended = true;
+    callback();
+  };
+
+  /**
+   * A kinesis stream persists beyond the duration of a readable stream. In order
+   * to stop reading from the stream, call `.close()`. Then listen for the `end`
+   * event to indicate that all data that as been read from Kinesis has been passed
+   * downstream.
+   *
+   * @instance
+   * @memberof KinesisClient
+   * @returns {KinesisClient}
+   */
+  checkpoint.close = function() {
+    drain = true;
+    if (!ended) readable._read();
+    return checkpoint;
+  };
+
+  /**
+   * A client that implements a node.js readable stream interface for reading kinesis
+   * records. See node.js documentation for details.
+   *
+   * In addition to the normal events emitted by a readable stream, the KinesisClient
+   * emits `checkpoint` events, which indicate the most recent sequence number that
+   * has been read from Kinesis and passed downstream.
+   *
+   * @name KinesisClient
+   */
+  return readable.pipe(checkpoint);
+}

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/rclark/kinesis-readable",
   "devDependencies": {
-    "kinesalite": "1.0.3",
+    "kinesalite": "^1.10.1",
     "queue-async": "^1.0.7",
-    "tape": "^3.5.0"
+    "tape": "^4.2.2"
   },
   "dependencies": {
-    "aws-sdk": "^2.1.16"
+    "aws-sdk": "^2.2.22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/rclark/kinesis-readable",
   "devDependencies": {
+    "eslint": "^1.10.3",
     "kinesalite": "^1.10.1",
     "queue-async": "^1.0.7",
     "tape": "^4.2.2"

--- a/readme.md
+++ b/readme.md
@@ -7,22 +7,20 @@ Node.js stream interface for reading records from [AWS Kinesis](http://aws.amazo
 ## Usage
 
 ```js
-var config = {
-  name: 'my-stream',
-  region: 'my-region'
-};
+var AWS = new AWS.Kinesis({
+  region: 'us-east-1',
+  params: { StreamName: 'my-stream' }
+});
 
-var Readable = require('kinesis-readable')(config);
-
-// See below for options
-var readable = new Readable(options);
+// see below for options
+var readable = require('kinesis-readable')(client, options);
 
 readable
   // 'data' events will trigger for a set of records in the stream
   .on('data', function(records) {
     console.log(records);
   })
-  // each time a GetRecords request is made, the 'checkpoint' event will provide
+  // each time a records are passed downstream, the 'checkpoint' event will provide
   // the last sequence number that has been read
   .on('checkpoint', function(sequenceNumber) {
     console.log(sequenceNumber);
@@ -49,14 +47,10 @@ You can pass options to create the readable stream, all parameters are optional:
 
 ```js
 var options = {
-  shardId: 'shard-identifier', // default to first shard in the stream
-  latest: true, // default to false
-  lastCheckpoint: '12345678901234567890', // start reading after this sequence number
-  limit: 100 // default to 1
+  shardId: 'shard-identifier', // defaults to first shard in the stream
+  iterator: 'LATEST', // default to TRIM_HORIZON
+  startAfter: '12345678901234567890', // start reading after this sequence number
+  startAt: '12345678901234567890', // start reading from this sequence number
+  limit: 100 // number of records per `data` event
 };
 ```
-
-- **shardId** allows you to specify which shard in your stream to read from
-- **latest** if true, begins reading records written to the stream *after* reading begins. Use this to ignore records written to the stream before you started listening.
-- **lastCheckpoint** pass a sequence number and the stream will start reading from the next record
-- **limit** allows you to set the maximum number of records that will be passed to any single `data` event


### PR DESCRIPTION
Adjusted the API so that you bring your own client.

```
var readable = require('kinesis-readable')(client, streamName, options);
```

`options` were adjusted to allow
- iterator types: LATEST, TRIM_HORIZON, AT_SEQUENCE_NUMBER, and AFTER_SEQUENCE_NUMBER
- limit: num records per request no longer defaults to 1

Adds some `setTimeout` to make sure that it doesn't hit 5 req per shard per s limitations.

refs #3 
fixes #4 
