### PR TITLE
add AT_TIMESTAMP iterator

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = KinesisReadable;
  * If unspecified, defaults to `TRIM_HORIZON`
  * @param {string} [options.startAt] - a sequence number to start reading from.
  * @param {string} [options.startAfter] - a sequence number to start reading after.
+ * @param {number} [options.timestamp] - a timestamp to start reading after.
  * @param {number} [options.limit] - the maximum number of records that will
  * be passed to any single `data` event.
  * @param {number} [options.readInterval] - time in ms to wait between getRecords API calls
@@ -76,6 +77,9 @@ function KinesisReadable(client, name, options) {
     } else if (options.startAfter) {
       params.ShardIteratorType = 'AFTER_SEQUENCE_NUMBER';
       params.StartingSequenceNumber = options.startAfter;
+    } else if (options.timestamp) {
+      params.ShardIteratorType = 'AT_TIMESTAMP';
+      params.Timestamp = options.timestamp;
     } else {
       params.ShardIteratorType = 'TRIM_HORIZON';
     }

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,7 @@ var options = {
   iterator: 'LATEST', // default to TRIM_HORIZON
   startAfter: '12345678901234567890', // start reading after this sequence number
   startAt: '12345678901234567890', // start reading from this sequence number
+  timestamp: '2016-04-04T19:58:46.480-00:00', // start reading from this timestamp
   limit: 100 // number of records per `data` event
 };
 ```


### PR DESCRIPTION
The only missing `ShardIteratorType` is `AT_TIMESTAMP`, if have inlcuded the options to set it and updated the README.

I could not write a test case, as this `ShardIteratorType` is not supported by `kinesalite`, mentioned in [#30](https://github.com/mhart/kinesalite/issues/30) and [#49](https://github.com/mhart/kinesalite/pull/49)